### PR TITLE
Assetview search

### DIFF
--- a/frontend/src/Components/ CryptoView/CryptoView.jsx
+++ b/frontend/src/Components/ CryptoView/CryptoView.jsx
@@ -1,3 +1,0 @@
-// use search by Id for this https://site.financialmodelingprep.com/developer/docs/stable/search-crypto-news
-import { useContext } from 'react';
-import { webFetchedContext } from "../../context/Webfetching/WebFetchContext";

--- a/frontend/src/Components/AllTickersView/AllTickersView.jsx
+++ b/frontend/src/Components/AllTickersView/AllTickersView.jsx
@@ -3,10 +3,12 @@ import { webFetchedContext } from "../../context/Webfetching/WebFetchContext";
 import { useContext } from 'react';
 import { Table, TableRow, TableCaption, TableBody } from "../ui/table"
 import { ScrollArea } from "../ui/scroll-area.jsx"
+import { useNavigate } from 'react-router-dom';
+
 const AllTickersView = () => {
     const { coinApiData, websocketData } = useContext(webFetchedContext) 
 
-    const navigate = useNavigate // routing for CryptoView
+    const navigate = useNavigate() // routing for CryptoView
 
     return (
         <ScrollArea className="h-[600px]  rounded-md border p-4 h-screen overflow-y-scroll">

--- a/frontend/src/Components/AllTickersView/AllTickersView.jsx
+++ b/frontend/src/Components/AllTickersView/AllTickersView.jsx
@@ -5,6 +5,9 @@ import { Table, TableRow, TableCaption, TableBody } from "../ui/table"
 import { ScrollArea } from "../ui/scroll-area.jsx"
 const AllTickersView = () => {
     const { coinApiData, websocketData } = useContext(webFetchedContext) 
+
+    const navigate = useNavigate // routing for CryptoView
+
     return (
         <ScrollArea className="h-[600px]  rounded-md border p-4 h-screen overflow-y-scroll">
             <Table className="border-4 border-black">
@@ -13,11 +16,20 @@ const AllTickersView = () => {
                     {coinApiData.map((coin) => {
                         const websocketPrice = websocketData[coin.id.toLowerCase()]
                         return (
+
+                            <div
+                                key = {coin.id}
+                                className = "cursor-pointer hover:bg-gray-100 transitiom-colors"
+                                onClick={() => navigate(`/assetview/${coin.id.toLowerCase()}`)} // takes user to cryptoview when clicked
+                            >
+
+
                             <TickerBox
-                                key={coin.id}
+                                
                                 coinData={coin}
                                 livePrice={websocketPrice}
                             />
+                            </div>
 
 
                         )

--- a/frontend/src/Components/NavBar/NavBar.jsx
+++ b/frontend/src/Components/NavBar/NavBar.jsx
@@ -45,7 +45,7 @@ export default function NavBar() {
                                 <input
                                     className="text-black placeholder:text-xs w-48"
                                     type="search"
-                                    placeholder="Search Ticker (ex: BTC)" 
+                                    placeholder="Search Ticker (ex: Bitcoin)" 
                                     value={searchInput}
                                     onChange={(e) => setSearchInput(e.target.value)}
                                     />

--- a/frontend/src/Components/NavBar/NavBar.jsx
+++ b/frontend/src/Components/NavBar/NavBar.jsx
@@ -1,8 +1,19 @@
 import React from "react";
 import { NavigationMenu, NavigationMenuList, NavigationMenuItem, NavigationMenuLink } from "../ui/navigation-menu"
 import { Link } from "react-router-dom";
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 export default function NavBar() {
+    const navigate = useNavigate()
+    const [searchInput, setSearchInput] = useState("")
 
+    const handleSearch = (e) => {
+        e.preventDefault();
+        if (searchInput.trim() !== "") {
+            navigate(`/assetview/${searchInput.trim().toLowerCase()}`)
+            setSearchInput("")
+        }
+    }
     return (
         <div className="container mx-auto p-4 flex flex-shrink">
             <NavigationMenu className="bg-blue-500 border-4 rounded-md w-full max-w-7xl font-bold flex-shrink justify-center">
@@ -30,9 +41,19 @@ export default function NavBar() {
                     </div>
                     <div className="flex flex-shrink">
                         <NavigationMenuItem className="border-4 rounded-md border-black text-black bg-white flex items-center gap-2">
-                            <form>
-                                <input className="text-black placeholder:text-xs w-48" type="search" placeholder="Search Ticker (ex: BTC)" />
-                                <button type="submit" className="bg-blue-500 text-white py-1 px-2 rounded-md">Search</button>
+                            <form onSubmit={handleSearch}>
+                                <input
+                                    className="text-black placeholder:text-xs w-48"
+                                    type="search"
+                                    placeholder="Search Ticker (ex: BTC)" 
+                                    value={searchInput}
+                                    onChange={(e) => setSearchInput(e.target.value)}
+                                    />
+                                <button
+                                    type="submit"
+                                    className="bg-blue-500 text-white py-1 px-2 rounded-md">
+                                    Search
+                                </button>
                             </form>
                         </NavigationMenuItem>
                     </div>

--- a/frontend/src/Components/RecommendedCrypto/RecommendedCrypto.jsx
+++ b/frontend/src/Components/RecommendedCrypto/RecommendedCrypto.jsx
@@ -1,0 +1,7 @@
+export default function RecommendedCrypto(){
+    return (
+        <div>
+            Recommended Crypto
+        </div>
+    )
+}

--- a/frontend/src/Components/RelatedNews/RelatedNews.jsx
+++ b/frontend/src/Components/RelatedNews/RelatedNews.jsx
@@ -3,8 +3,8 @@ import { useContext } from 'react';
 import { webFetchedContext } from "../../context/Webfetching/WebFetchContext";
 // use search by Id for this https://site.financialmodelingprep.com/developer/docs/stable/search-crypto-news to search and load news based on it, use api caching
 
-export default RelatedNews = () =>{
+export default  function RelatedNews(){
     return(
-        <div>HI</div>
+        <div>Related News: </div>
     )
 }

--- a/frontend/src/Components/Router/router.jsx
+++ b/frontend/src/Components/Router/router.jsx
@@ -33,7 +33,7 @@ export const router = createBrowserRouter([
             // Protected routes
             { path: "/dashboard", element: <PrivateRoute><Dashboard /></PrivateRoute> },
             { path: "/alltickers", element: <PrivateRoute><AllTickers /></PrivateRoute> },
-            { path: "/assetview", element: <PrivateRoute><AssetView /></PrivateRoute> },
+            { path: "/assetview/:symbol", element: <PrivateRoute><AssetView /></PrivateRoute> },
             { path: "/news", element: <PrivateRoute><News /></PrivateRoute> },
             { path: "/watchlist", element: <PrivateRoute><WatchList /></PrivateRoute> },
             { path: "/portfolio", element: <PrivateRoute><Portfolio /></PrivateRoute> },

--- a/frontend/src/Components/TickerBox/TickerBox.jsx
+++ b/frontend/src/Components/TickerBox/TickerBox.jsx
@@ -1,10 +1,12 @@
 import { useState, useEffect, useRef } from 'react'
 import { TableCell, TableRow } from '../ui/table'
+import { useNavigate } from 'react-router-dom'
 
 export default function TickerBox({ coinData, livePrice }) {
     const [priceColor, setPriceColor] = useState('text-white')
     const previousPrice = useRef(null) // reference to price before new price
     
+
 
     // sets color of price to green if higher than prev, red if lower, white if equal
     useEffect(() => {

--- a/frontend/src/Components/TickerBox/TickerBox.jsx
+++ b/frontend/src/Components/TickerBox/TickerBox.jsx
@@ -39,7 +39,7 @@ export default function TickerBox({ coinData, livePrice }) {
                 <img src={coinData.image} alt={coinData.symbol} className="w-12 h-auto" />
             </TableCell>
             <TableCell className="text-lg font-bold">{coinData.symbol.toUpperCase()}</TableCell>
-            <TableCell className={`${priceColor} text-lg font-bold`}>$ {livePrice}</TableCell>
+            <TableCell className={`${priceColor} text-lg font-bold`}>$ {livePrice.toFixed(4)}</TableCell>
             <TableCell className="text-sm">Volume: {coinData.total_volume}</TableCell>
             <TableCell className="text-sm">High: {coinData.high_24h}</TableCell>
             <TableCell className="text-sm">Low: {coinData.low_24h}</TableCell>

--- a/frontend/src/Pages/AssetView/AssetView.jsx
+++ b/frontend/src/Pages/AssetView/AssetView.jsx
@@ -8,7 +8,7 @@ export default function AssetView() {
     const { coinApiData, websocketData } = useContext(webFetchedContext)
     const { symbol } = useParams()
     const coin = coinApiData.find(coin => coin.id.toLowerCase() === symbol.toLowerCase()) // find matching symbol in data
-    const livePrice = websocketData[symbol.toLowerCase]
+    const livePrice = websocketData[symbol.toLowerCase()]
 
     if (!coin) {
         return (
@@ -20,7 +20,7 @@ export default function AssetView() {
     return (
         <div>
             <h1>
-                {coin.symbol} + {livePrice}
+                {livePrice}
             </h1>
         </div>
     )

--- a/frontend/src/Pages/AssetView/AssetView.jsx
+++ b/frontend/src/Pages/AssetView/AssetView.jsx
@@ -2,13 +2,40 @@ import React from 'react';
 import { useParams } from 'react-router-dom';
 import { webFetchedContext } from "../../context/Webfetching/WebFetchContext";
 import { useContext } from 'react';
-
+import { useState, useRef, useEffect } from 'react';
 
 export default function AssetView() {
-    const { coinApiData, websocketData } = useContext(webFetchedContext)
+    const { coinApiData, websocketData, newsApiData } = useContext(webFetchedContext)
     const { symbol } = useParams()
     const coin = coinApiData.find(coin => coin.id.toLowerCase() === symbol.toLowerCase()) // find matching symbol in data
     const livePrice = websocketData[symbol.toLowerCase()]
+
+    const [priceColor, setPriceColor] = useState('text-white')
+    const previousPrice = useRef(null) // reference to price before new price
+
+    // sets color of price to green if higher than prev, red if lower, white if equal
+    useEffect(() => {
+        if (previousPrice.current == null) {
+            previousPrice.current = livePrice
+            return
+        }
+        if (livePrice > previousPrice.current) {
+            setPriceColor('text-red-600')
+        } else if (livePrice < previousPrice.current) {
+            setPriceColor('text-green-600')
+        } else {
+            setPriceColor('text-black')
+        }
+        previousPrice.current = livePrice
+    }, [livePrice])
+
+    const addToWatchlist = (e) => {
+        console.log(`added ${dataStreamed.s} to watch list`)
+    }
+
+    const openModal = (e) => {
+        console.log("modal openeed")
+    }
 
     if (!coin) {
         return (
@@ -19,9 +46,33 @@ export default function AssetView() {
     }
     return (
         <div>
-            <h1>
-                {livePrice}
+            <img src={coin.image} alt={coin.symbol} className="w-12 h-auto" />
+            <h1></h1>
+            <h1 className={`${priceColor} text-lg font-bold`} >
+                ${livePrice}
             </h1>
+            <h1>{coin.current_price}</h1>
+            <h1>{coin.market_cap}</h1>
+            <h1>{coin.market_cap_rank}</h1>
+            <h1>{coin.fully_diluted_valuation}</h1>
+            <h1>{coin.total_volume}</h1>
+            <h1>{coin.high_24h}</h1>
+            <h1>{coin.low_24h}</h1>
+            <h1>{coin.price_change_24h}</h1>
+            <h1>{coin.price_change_percentage_24h}</h1>
+            <h1>{coin.market_cap_change_24h}</h1>
+            <h1>{coin.market_cap_change_percentage_24h}</h1>
+            <h1>{coin.circulating_supply}</h1>
+            <h1>{coin.total_supply}</h1>
+            <h1>{coin.max_supply}</h1>
+            <h1>{coin.ath}</h1>
+            <h1>{coin.ath_change_percentage}</h1>
+            <h1>{coin.ath_date}</h1>
+            <h1>{coin.atl}</h1>
+            <h1>{coin.atl_change_percentage}</h1>
+            <h1>{coin.atl_date}</h1>
+            <h1>{coin.roi}</h1>
+            <h1>{coin.last_updated}</h1>
         </div>
     )
 

--- a/frontend/src/Pages/AssetView/AssetView.jsx
+++ b/frontend/src/Pages/AssetView/AssetView.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 export default function AssetView() {
     return <div>AssetView</div>;
 }

--- a/frontend/src/Pages/AssetView/AssetView.jsx
+++ b/frontend/src/Pages/AssetView/AssetView.jsx
@@ -45,8 +45,12 @@ export default function AssetView() {
         )
     }
     return (
-        <div>
-            <img src={coin.image} alt={coin.symbol} className="w-12 h-auto" />
+        <div className="max-w-screen-xl mx-auto px-6 py-8 text-white">
+            <div className='mb-4'>
+                <img src={coin.image} alt={coin.symbol} className="w-12 h-auto" />
+                <div className="text-3x font-bold">{coin.name} ({coin.symbol.toUpperCase()})</div>
+            </div>
+
             <h1></h1>
             <h1 className={`${priceColor} text-lg font-bold`} >
                 ${livePrice}

--- a/frontend/src/Pages/AssetView/AssetView.jsx
+++ b/frontend/src/Pages/AssetView/AssetView.jsx
@@ -71,7 +71,6 @@ export default function AssetView() {
             <h1>{coin.atl}</h1>
             <h1>{coin.atl_change_percentage}</h1>
             <h1>{coin.atl_date}</h1>
-            <h1>{coin.roi}</h1>
             <h1>{coin.last_updated}</h1>
         </div>
     )

--- a/frontend/src/Pages/AssetView/AssetView.jsx
+++ b/frontend/src/Pages/AssetView/AssetView.jsx
@@ -46,36 +46,57 @@ export default function AssetView() {
     }
     return (
         <div className="max-w-screen-xl mx-auto px-6 py-8 text-white">
-            <div className='mb-4'>
-                <img src={coin.image} alt={coin.symbol} className="w-12 h-auto" />
-                <div className="text-3x font-bold">{coin.name} ({coin.symbol.toUpperCase()})</div>
+
+            {/*Headers for Page*/}
+            <div className='mb-4 flex items-center space-x-6 mb-8'>
+                <img src={coin.image} alt={coin.symbol} className="w-20 h-20 object-cointain rounded-xl border-2 border-gray-600" />
+                <div>
+                    <h1 className="text-3x font-bold">{coin.name} ({coin.symbol.toUpperCase()})</h1>
+                    <p className={`text-2xl mt-2 ${priceColor}`}>Live: {livePrice}</p>
+                </div>
             </div>
 
-            <h1></h1>
-            <h1 className={`${priceColor} text-lg font-bold`} >
-                ${livePrice}
-            </h1>
-            <h1>{coin.current_price}</h1>
-            <h1>{coin.market_cap}</h1>
-            <h1>{coin.market_cap_rank}</h1>
-            <h1>{coin.fully_diluted_valuation}</h1>
-            <h1>{coin.total_volume}</h1>
-            <h1>{coin.high_24h}</h1>
-            <h1>{coin.low_24h}</h1>
-            <h1>{coin.price_change_24h}</h1>
-            <h1>{coin.price_change_percentage_24h}</h1>
-            <h1>{coin.market_cap_change_24h}</h1>
-            <h1>{coin.market_cap_change_percentage_24h}</h1>
-            <h1>{coin.circulating_supply}</h1>
-            <h1>{coin.total_supply}</h1>
-            <h1>{coin.max_supply}</h1>
-            <h1>{coin.ath}</h1>
-            <h1>{coin.ath_change_percentage}</h1>
-            <h1>{coin.ath_date}</h1>
-            <h1>{coin.atl}</h1>
-            <h1>{coin.atl_change_percentage}</h1>
-            <h1>{coin.atl_date}</h1>
-            <h1>{coin.last_updated}</h1>
+            {/*Buttons */}
+            <div className="mb-6 flex space-x-4 flex items-center">
+                <button
+                    onClick={addToWatchlist}
+                    className="flex items-center gap-1 bg-yellow-200 hover:bg-yellow-400 transition duration-300 ease-in-out rounded-lg py-2 px-4"
+                >
+                    <h2 className="text-lg font-bold">Add to Watchlist</h2>
+                    <h2 className="text-yellow-600 text-2xl">★</h2>
+                </button>
+
+                <button
+                    className="bg-yellow-200 hover:bg-yellow-400 rounded-lg transition duration-300 ease-in-out py-2 px-4"
+                    type="submit"
+                >
+                    Add to Portfolio
+                </button>
+            </div>
+            {/*Stats for Crypto */}
+
+            <div className='grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 text-sm'>
+            <h1>Current Price: ${coin.current_price}</h1>
+            <h1>Market Cap: ${coin.market_cap}</h1>
+            <h1>Market Cap Rank: {coin.market_cap_rank}</h1>
+            <h1>Valuation: {coin.fully_diluted_valuation}</h1>
+            <h1>Total Daily Volume: {coin.total_volume}</h1>
+            <h1>High of Day: {coin.high_24h}</h1>
+            <h1>Low of Day: {coin.low_24h}</h1>
+            <h1>Daily Price Chnage: {coin.price_change_24h}</h1>
+            <h1>Price Change Percentage: {coin.price_change_percentage_24h}%</h1>
+            <h1>24 Hour Market Cap Change: {coin.market_cap_change_24h}</h1>
+            <h1>24 Hour Market Cap Change Percentage: {coin.market_cap_change_percentage_24h}%</h1>
+            <h1>Circulating Supply: {coin.circulating_supply}</h1>
+            <h1>Total Supply: {coin.total_supply}</h1>
+            <h1>Max Supply:{coin.max_supply}</h1>
+            <h1>All Time High: {coin.ath}</h1>
+            <h1>All Time High Change Percentage: {coin.ath_change_percentage}%</h1>
+            <h1>All Time High Date: {coin.ath_date}</h1>
+            <h1> All Time Low: {coin.atl}</h1>
+            <h1>All Time Low Change Percentage: {coin.atl_change_percentage}%</h1>
+            <h1>All Time Low Date:{coin.atl_date}</h1>
+            </div>
         </div>
     )
 

--- a/frontend/src/Pages/AssetView/AssetView.jsx
+++ b/frontend/src/Pages/AssetView/AssetView.jsx
@@ -1,5 +1,28 @@
 import React from 'react';
+import { useParams } from 'react-router-dom';
+import { webFetchedContext } from "../../context/Webfetching/WebFetchContext";
+import { useContext } from 'react';
+
 
 export default function AssetView() {
-    return <div>AssetView</div>;
+    const { coinApiData, websocketData } = useContext(webFetchedContext)
+    const { symbol } = useParams()
+    const coin = coinApiData.find(coin => coin.id.toLowerCase() === symbol.toLowerCase()) // find matching symbol in data
+    const livePrice = websocketData[symbol.toLowerCase]
+
+    if (!coin) {
+        return (
+            <div className="text-red-500">
+                Asset Not Found for: ${symbol}
+            </div>
+        )
+    }
+    return (
+        <div>
+            <h1>
+                {coin.symbol} + {livePrice}
+            </h1>
+        </div>
+    )
+
 }


### PR DESCRIPTION
This PR adds asset view for all listed cryptos, when a user searches for a coin or clicks on the tickers they are routed to a page showing the details of a crypto

In the future, this page will have related cryptocurrencies, recommended cryptocurrencies and related news articles.

As an investor, I want a search page for crypto research on the website, similar to Yahoo Finance, so that I can find detailed information about specific assets.




Used Useparams to get the id of the crypto clicked on, made changes in routing for asset view to have a symbol component to it

<img width="1427" alt="Screenshot 2025-07-05 at 5 53 23 PM" src="https://github.com/user-attachments/assets/d30f48bd-b079-4473-b96b-560934bf1aba" />

