### PR TITLE
Db schema

### DIFF
--- a/news-cron-server/prisma/schema.prisma
+++ b/news-cron-server/prisma/schema.prisma
@@ -13,3 +13,24 @@ datasource db {
   provider = "postgresql"
   url      = env("DATABASE_URL")
 }
+
+model Article {
+  id        Int    @id @default(autoincrement())
+  guid      String
+  title     String
+  keywords  String // for parsing for nodemailer to find which symbol its for
+  image_url String
+
+  // SentimentScore breakdown
+  sentiment     String
+  mixedScore    Float
+  negativeScore Float
+  neutralScore  Float
+  positiveScore Float
+
+  sent        Boolean
+  createdAt   DateTime @default(now())
+  publishedOn DateTime @map("PUBLISHED_ON")
+
+  @@unique([guid])
+}

--- a/news-cron-server/prisma/schema.prisma
+++ b/news-cron-server/prisma/schema.prisma
@@ -30,7 +30,7 @@ model Article {
 
   sent        Boolean
   createdAt   DateTime @default(now())
-  publishedOn DateTime @map("PUBLISHED_ON")
+  publishedOn DateTime @map("PUBLISHED_ON") // convert date frmo api in to JS date
 
   @@unique([guid])
 }


### PR DESCRIPTION
## Description
This PR merges the Database schema for articles being put in the database into the AWS comprehend branch - which fetches the news data and then parses the titles through AWS comprehend to be evaluated for sentiment.


https://docs.google.com/document/d/1f1F0ui0pLvHa_9mdearynn-g3xRrlREDbUM2jluzVuc/edit?tab=t.0
https://docs.google.com/document/d/1caxzRLiKQk0_MtFrnqomYi177tcNThhMq8kmBgMRzAQ/edit?usp=sharing

Working towards users can be notified of important news and be shown this on website


## Test Plan

Just showing that was able to add and filter out articles with benchmark score of 0 using test data and filter out by ratio of negative or positive. Only articles with benchmakr > 0 and pos to neg ratio of 3 or 1/3 above
<img width="480" height="519" alt="Screenshot 2025-07-11 at 2 51 30 PM" src="https://github.com/user-attachments/assets/9f8dc1c0-a3d1-4a41-80c1-5df14099976d" />


<img width="451" height="384" alt="Screenshot 2025-07-11 at 2 49 58 PM" src="https://github.com/user-attachments/assets/77a785b0-c0e7-4eca-b68e-a3ccb4861f31" />
