### PR TITLE
fixed pie chart cutting off on hover

### DIFF
--- a/frontend/src/Components/PieChart/PieChart.jsx
+++ b/frontend/src/Components/PieChart/PieChart.jsx
@@ -90,6 +90,7 @@ export default function Piechart() {
             viewBox="-1 -1 2 2"
             width="250"
             height="250"
+            style = {{overflow: "visible"}}
         >
             {paths}
         </svg>


### PR DESCRIPTION
## Description
This PR fixes the issue of the portfolio pie chart slices cutting off when they are hovered over in some instances


## Milestones

Users can see a pie chart of their portfolio

## Test Plan

https://pxl.cl/7JDSp