### PR TITLE
Stretch historic pl

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -10,6 +10,7 @@ app.use('/api/watchlist' , require('./routes/watchlist'))
 app.use('/api/transactions' , require('./routes/transactions'))
 app.use('/api/portfolionews',require('./routes/news'))
 app.use('/api/recommendations', require('./routes/recommendations'))
+app.use('api/stats', require('./routes/stats') )
 
 app.listen(PORT, () =>{
     console.log(`server running on port ${PORT}`)

--- a/backend/index.js
+++ b/backend/index.js
@@ -10,7 +10,7 @@ app.use('/api/watchlist' , require('./routes/watchlist'))
 app.use('/api/transactions' , require('./routes/transactions'))
 app.use('/api/portfolionews',require('./routes/news'))
 app.use('/api/recommendations', require('./routes/recommendations'))
-app.use('api/stats', require('./routes/stats') )
+app.use('/api/stats', require('./routes/stats') )
 
 app.listen(PORT, () =>{
     console.log(`server running on port ${PORT}`)

--- a/backend/prisma/migrations/20250718221949_historicprofit/migration.sql
+++ b/backend/prisma/migrations/20250718221949_historicprofit/migration.sql
@@ -1,0 +1,12 @@
+-- CreateTable
+CREATE TABLE "HistoricProfit" (
+    "id" SERIAL NOT NULL,
+    "userId" TEXT NOT NULL,
+    "profit" DOUBLE PRECISION NOT NULL,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "HistoricProfit_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "HistoricProfit_userId_key" ON "HistoricProfit"("userId");

--- a/backend/prisma/migrations/20250718224135_add_post_model/migration.sql
+++ b/backend/prisma/migrations/20250718224135_add_post_model/migration.sql
@@ -1,0 +1,15 @@
+-- CreateTable
+CREATE TABLE "HistoricProfitPoint" (
+    "id" SERIAL NOT NULL,
+    "userId" TEXT NOT NULL,
+    "profit" DOUBLE PRECISION NOT NULL,
+    "timestamp" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "HistoricProfitPoint_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "HistoricProfitPoint_userId_idx" ON "HistoricProfitPoint"("userId");
+
+-- CreateIndex
+CREATE INDEX "HistoricProfitPoint_timestamp_idx" ON "HistoricProfitPoint"("timestamp");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -78,3 +78,10 @@ model Recommendation {
   @@unique([userId, symbol])
   @@index([userId])
 }
+
+model HistoricProfit {
+  id Int @id @default(autoincrement())
+  userId String @unique // only can have one per user
+  profit Float // can be negative
+  updatedAt DateTime @updatedAt
+}

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -85,3 +85,12 @@ model HistoricProfit {
   profit Float // can be negative
   updatedAt DateTime @updatedAt
 }
+
+model HistoricProfitPoint{
+  id  Int @id @default(autoincrement())
+  userId String
+  profit Float
+  timestamp DateTime @default(now())
+  @@index([userId])
+  @@index([timestamp])
+}

--- a/backend/routes/stats.js
+++ b/backend/routes/stats.js
@@ -33,3 +33,5 @@ router.get('/historic-profit/:userId', async (req, res) => {
     }
     res.json(profit);
 });
+
+module.exports = router;

--- a/backend/routes/stats.js
+++ b/backend/routes/stats.js
@@ -1,0 +1,35 @@
+const express = require('express');
+const { PrismaClient } = require('@prisma/client');
+
+const router = express.Router();
+const prisma = new PrismaClient();
+
+
+// for recharts, get every single profit point
+router.get('/historic-profit-points/:userId', async (req, res) => {
+    const { userId } = req.params;
+    const points = await prisma.historicProfitPoint.findMany({
+        where: { userId },
+        orderBy: { timestamp: 'asc' }, // or 'desc' if you want latest first
+    });
+    res.json(points);
+});
+
+// get all users current historical Profit/Realized profit
+router.get('/historic-profit', async (req, res) => {
+    const profits = await prisma.historicProfit.findMany();
+    res.json(profits);
+});
+
+
+// get one users historic profit
+router.get('/historic-profit/:userId', async (req, res) => {
+    const { userId } = req.params;
+    const profit = await prisma.historicProfit.findUnique({
+        where: { userId },
+    });
+    if (!profit) {
+        return res.status(404).json({ error: 'HistoricProfit not found for user' });
+    }
+    res.json(profit);
+});

--- a/backend/routes/transactions.js
+++ b/backend/routes/transactions.js
@@ -53,8 +53,30 @@ router.post('/', async (req, res) => {
                     data: { quantity: newQuant },
                 });
             }
-        }
 
+            // code for updating historical profit and loss, curr price * quantity average price bought * quantity 
+            const profit = (p - existingEntry.avgPrice) * quantity
+
+            const existingProfit = await prisma.historicProfit.findUnique({
+                where: { userId },
+            })
+
+            if (existingProfit) {
+                await prisma.historicProfit.update({
+                    where: { userId },
+                    data: {
+                        profit: existingProfit + profit
+                    }
+                })
+            } else {
+                prisma.historicProfit.create({
+                    data: {
+                        userId,
+                        profit: profit,
+                    },
+                })
+            }
+        }
         await prisma.transaction.create({
             data: {
                 userId,
@@ -64,7 +86,6 @@ router.post('/', async (req, res) => {
                 type: isBuy ? 'BUY' : 'SELL',
             },
         });
-
         res.json({ success: true, message: `${type.toUpperCase()} ${symbol.toUpperCase()}` });
     } catch (error) {
         console.error(error);

--- a/backend/routes/transactions.js
+++ b/backend/routes/transactions.js
@@ -57,6 +57,11 @@ router.post('/', async (req, res) => {
             // code for updating historical profit and loss, curr price * quantity average price bought * quantity 
             const profit = (p - existingEntry.avgPrice) * quant
 
+            //create pricepoint for data
+
+            
+
+            // current profit update
             const existingProfit = await prisma.historicProfit.findUnique({
                 where: { userId },
             })

--- a/backend/routes/transactions.js
+++ b/backend/routes/transactions.js
@@ -55,7 +55,7 @@ router.post('/', async (req, res) => {
             }
 
             // code for updating historical profit and loss, curr price * quantity average price bought * quantity 
-            const profit = (p - existingEntry.avgPrice) * quantity
+            const profit = (p - existingEntry.avgPrice) * quant
 
             const existingProfit = await prisma.historicProfit.findUnique({
                 where: { userId },
@@ -65,11 +65,11 @@ router.post('/', async (req, res) => {
                 await prisma.historicProfit.update({
                     where: { userId },
                     data: {
-                        profit: existingProfit + profit
+                        profit: existingProfit.profit + profit
                     }
                 })
             } else {
-                prisma.historicProfit.create({
+                await prisma.historicProfit.create({
                     data: {
                         userId,
                         profit: profit,

--- a/frontend/src/Components/HistoryChart/HistoryChart.jsx
+++ b/frontend/src/Components/HistoryChart/HistoryChart.jsx
@@ -14,7 +14,7 @@ import {
 
 export default function HistoryChart() {
     const { historicProfitPoints } = useBackendAttributes();
-
+    console.log(historicProfitPoints)
     // Sort data by timestamp ascending
     const sortedData = [...historicProfitPoints].sort(
         (a, b) => new Date(a.timestamp) - new Date(b.timestamp)
@@ -44,7 +44,9 @@ export default function HistoryChart() {
                     type="monotone"
                     dataKey="profit"
                     stroke={lineColor}
-                    activeDot={{ r: 8 }}
+                    strokeWidth={5}
+                    dot={{ r: 6 }}         // normal point radius
+                    activeDot={{ r: 10 }}
                     name="Profit"
                 />
             </LineChart>

--- a/frontend/src/Components/HistoryChart/HistoryChart.jsx
+++ b/frontend/src/Components/HistoryChart/HistoryChart.jsx
@@ -14,7 +14,6 @@ import {
 
 export default function HistoryChart() {
     const { historicProfitPoints } = useBackendAttributes();
-    console.log(historicProfitPoints)
     // Sort data by timestamp ascending
     const sortedData = [...historicProfitPoints].sort(
         (a, b) => new Date(a.timestamp) - new Date(b.timestamp)

--- a/frontend/src/Components/NavBar/NavBar.jsx
+++ b/frontend/src/Components/NavBar/NavBar.jsx
@@ -32,8 +32,9 @@ export default function NavBar() {
     }
     return (
         <nav className="bg-blue-500 text-white w-full px-4 py-3 flex items-center justify-between relative">
-            <h1>
+            <h1 className=" flex gap-4">
                 <Link to="/dashboard">CryptoApp</Link>
+                <Link to= "/stats">Your All Time Statistics</Link>
             </h1>
             <Button
                 onClick={handleSignOut}

--- a/frontend/src/Components/Router/router.jsx
+++ b/frontend/src/Components/Router/router.jsx
@@ -31,6 +31,7 @@ const News = lazyWithDelay(() => import("../../Pages/News/News"));
 const Portfolio = lazyWithDelay(() => import("../../Pages/Portfolio/Portfolio"));
 const Recommendations = lazyWithDelay(() => import("../../Pages/Recommendations/Recommendations"));
 const WatchList = lazyWithDelay(() => import("../../Pages/Watchlist/Watchlist"));
+const YourStats = lazyWithDelay(() => import("../../Pages/YourStats/YourStats"))
 
 // ui for loading
 export const LoadingSpinner = ({ className }) => {
@@ -210,6 +211,23 @@ export const router = createBrowserRouter([
                         </React.Suspense>
                     </PrivateRoute>
                 ),
+            },
+            {
+                path: "/stats",
+                element: (
+                    <PrivateRoute>
+                        <React.Suspense
+                            fallback={
+                                <div className="flex flex-col justify-center items-center h-screen text-xl space-y-4">
+                                    Loading... <LoadingSpinner className="w-12 h-12" />
+                                </div>
+                            }
+                        >
+                            <YourStats/>
+                        </React.Suspense>
+                    </PrivateRoute>
+                ),
+
             },
         ],
     },

--- a/frontend/src/Components/Stats/Stats.jsx
+++ b/frontend/src/Components/Stats/Stats.jsx
@@ -4,7 +4,6 @@ import { useBackendAttributes } from "../../context/BackEndContext";
 
 export default function Stats() {
     const { historicProfit } = useBackendAttributes();
-    console.log(historicProfit)
     // Extract profit value safely, fallback to 0 if undefined
     const profitValue = historicProfit.profit
 

--- a/frontend/src/Components/Stats/Stats.jsx
+++ b/frontend/src/Components/Stats/Stats.jsx
@@ -4,8 +4,9 @@ import { useBackendAttributes } from "../../context/BackEndContext";
 
 export default function Stats() {
     const { historicProfit } = useBackendAttributes();
+    console.log(historicProfit)
     // Extract profit value safely, fallback to 0 if undefined
-    const profitValue = historicProfit
+    const profitValue = historicProfit.profit
 
     return (
         <div

--- a/frontend/src/context/BackEndContext.jsx
+++ b/frontend/src/context/BackEndContext.jsx
@@ -14,6 +14,20 @@ export const BackEndContextProvider = ({ children }) => {
     const [transactions, setTransactions] = useState([]);
     const [relatedNews, setRelatedNews] = useState([])
     const [recommendations, setRecommendations] = useState([])
+    const [historicProfit, setHistoricProfit] = useState(null)
+    const [historicProfitPoints, setHistoricProfitPoints] = useState([])
+
+    const fetchHistoricProfits = async () => {
+        const res = await fetch(`${BACKEND_BASE_URL}/api/stats/historic-profit-points/${userId}`);
+        const data = await res.json();
+        setHistoricProfitPoints(data);
+    }
+
+    const fetchHistoricalProfit = async () => {
+        const res = await fetch(`${BACKEND_BASE_URL}/api/stats/historic-profit/${userId}`);
+        const data = await res.json();
+        setHistoricProfit(data);
+    }
 
     const fetchRecommendations = async () => {
         const res = await fetch(`${BACKEND_BASE_URL}/api/recommendations/${userId}`);
@@ -54,6 +68,8 @@ export const BackEndContextProvider = ({ children }) => {
         fetchTransactions();
         fetchNews()
         fetchRecommendations()
+        fetchHistoricProfits()
+        fetchHistoricalProfit()
     }, [session]);
 
     return (
@@ -65,6 +81,8 @@ export const BackEndContextProvider = ({ children }) => {
                 transactions,
                 relatedNews,
                 recommendations,
+                historicProfit,
+                historicProfitPoints,
                 fetchTransactions,
                 fetchPortfolio,
                 fetchWatchlist,


### PR DESCRIPTION

## Description

This Pull Request adds a stats page for users to see their total realized profit. Total Realized profit is the money they have made from past transactions ex. Positions they no longer hold but made a profit off of, so they can track how much they have made in real cash. It also adds a chart so users can see their profit over time.

next I will add a profile creation tab, where users can change their username and give themselves a profile picture, and a chart of a cryptocurrency.w

## Milestones

This takes care of the stretch goal historical position loss
 0. Historical position loss


## Test Plan
I calculated the position loss at points where it should be and htey matched up, heres an example of my look for stats.
<img width="961" height="692" alt="Screenshot 2025-07-22 at 11 39 17 AM" src="https://github.com/user-attachments/assets/36ffaf1f-fc86-4825-bd1c-c50a0073eccf" />

